### PR TITLE
avoid checking RECONNECT_WAIT by suppress_sec for testing reconnect

### DIFF
--- a/t/04_live.t
+++ b/t/04_live.t
@@ -52,6 +52,8 @@ subtest error => sub {
     is $r => undef, "connection refused";
     like $logger->errstr => qr/Connection refused/i;
 
+    sleep 1;
+
     # restart server on the same port
     ($server, $dir) = run_fluentd($port);
     ok $logger->post( "test.error" => { foo => "reconnected?" } ), "reconnected";


### PR DESCRIPTION
This is for failed test with 04_live.t.

I'm trying to install Fluent::Logger and failed it.

It is because to reconnect test that reached line number 57 in 04_live.t.

This test is need to wait for reconnect.
