### PR TITLE
FreeBSDでテストが通るようにしました

### DIFF
--- a/t/04_live.t
+++ b/t/04_live.t
@@ -50,7 +50,7 @@ subtest error => sub {
 
     $r = $logger->post( "test.error" => { "foo" => "connection refused?" } );
     is $r => undef, "connection refused";
-    like $logger->errstr => qr/Connection refused/i;
+    like $logger->errstr => qr/Can't connect: (?:Connection refused|Invalid argument)/i;
 
     sleep 1;
 


### PR DESCRIPTION
こんにちは！

FreeBSDで動かしてみたのですが、テストがこけるようです。。。

Linux環境

```
% prove -I lib t
t/00_compile.t ......... ok
t/01_new.t ............. ok
t/02_unix_socket.t ..... ok
t/03_tcp.t ............. ok
t/04_live.t ............ 2/? 2013-09-08T00:31:20+0900 Fluent::Logger[159302336](127.0.0.1:50906): message 'not hashref?' must be a HashRef at t/04_live.t line 43
Use of uninitialized value $nwrite in addition (+) at /home/.users/35/bokutin/code/reading/fluent-logger-perl-master/lib/Fluent/Logger.pm line 290.
2013-09-08T00:31:20+0900 Fluent::Logger[159302336](127.0.0.1:50906): Cannot send data: Broken pipe at /home/.users/35/bokutin/code/reading/fluent-logger-perl-master/lib/Fluent/Logger.pm line 278. at t/04_live.t line 47
2013-09-08T00:31:20+0900 Fluent::Logger[159302336](127.0.0.1:50906): Can't connect: Connection refused at t/04_live.t line 51
2013-09-08T00:31:20+0900 Fluent::Logger[159302336](127.0.0.1:50906): Cannot send data: Can't call method "syswrite" on an undefined value at /home/.users/35/bokutin/code/reading/fluent-logger-perl-master/lib/Fluent/Logger.pm line 281. at t/04_live.t line 51
Use of uninitialized value $nwrite in addition (+) at /home/.users/35/bokutin/code/reading/fluent-logger-perl-master/lib/Fluent/Logger.pm line 290.
2013-09-08T00:31:24+0900 Fluent::Logger[159302336](127.0.0.1:50906): Cannot send data: Broken pipe at /home/.users/35/bokutin/code/reading/fluent-logger-perl-master/lib/Fluent/Logger.pm line 278. at t/04_live.t line 65
t/04_live.t ............ 3/? 2013-09-08T00:31:24+0900 Fluent::Logger[159327424](127.0.0.1:50906): Can't connect: Connection refused at t/04_live.t line 80
t/04_live.t ............ ok
t/05_prefer_integer.t .. 1/? 2013-09-08T00:31:26+0900 Fluent::Logger[164045824](127.0.0.1:24224): Can't connect: Connection refused at t/05_prefer_integer.t line 17
t/05_prefer_integer.t .. ok
t/06_fork.t ............ ok
All tests successful.
Files=7, Tests=32, 17 wallclock secs ( 0.08 usr  0.10 sys +  3.35 cusr  4.12 csys =  7.65 CPU)
Result: PASS
```

FreeBSD 9.1環境

```
% prove -I lib t/
t/00_compile.t ......... ok
t/01_new.t ............. ok
t/02_unix_socket.t ..... ok
t/03_tcp.t ............. ok
t/04_live.t ............ 2/? 2013-09-08T00:32:24+0900 Fluent::Logger[34409608608](127.0.0.1:50905): message 'not hashref?' must be a HashRef at t/04_live.t line 43.
2013-09-08T00:32:24+0900 Fluent::Logger[34409608608](127.0.0.1:50905): Cannot send data: Broken pipe at /usr/home/bokutin/code/reading/fluent-logger-perl/lib/Fluent/Logger.pm line 278. at t/04_live.t line 47.
2013-09-08T00:32:24+0900 Fluent::Logger[34409608608](127.0.0.1:50905): Can't connect: Invalid argument at t/04_live.t line 51.
2013-09-08T00:32:24+0900 Fluent::Logger[34409608608](127.0.0.1:50905): Cannot send data: Can't call method "syswrite" on an undefined value at /usr/home/bokutin/code/reading/fluent-logger-perl/lib/Fluent/Logger.pm line 281. at t/04_live.t line 51.

    #   Failed test at t/04_live.t line 53.
    #                   'message 'not hashref?' must be a HashRef
    # Cannot send data: Broken pipe at /usr/home/bokutin/code/reading/fluent-logger-perl/lib/Fluent/Logger.pm line 278.
    #
    # Can't connect: Invalid argument
    # Cannot send data: Can't call method "syswrite" on an undefined value at /usr/home/bokutin/code/reading/fluent-logger-perl/lib/Fluent/Logger.pm line 281.
    # '
    #     doesn't match '(?^i:Connection refused)'
2013-09-08T00:32:28+0900 Fluent::Logger[34409608608](127.0.0.1:50905): Cannot send data: Broken pipe at /usr/home/bokutin/code/reading/fluent-logger-perl/lib/Fluent/Logger.pm line 278. at t/04_live.t line 65.
    # Looks like you failed 1 test of 11.
t/04_live.t ............ 3/?
#   Failed test 'error'
#   at t/04_live.t line 77.
2013-09-08T00:32:28+0900 Fluent::Logger[34409639872](127.0.0.1:50905): Can't connect: Invalid argument at t/04_live.t line 80.
# Looks like you failed 1 test of 4.
t/04_live.t ............ Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/4 subtests
t/05_prefer_integer.t .. ok
t/06_fork.t ............ ok

Test Summary Report
-------------------
t/04_live.t          (Wstat: 256 Tests: 4 Failed: 1)
  Failed test:  3
  Non-zero exit status: 1
Files=7, Tests=32, 13 wallclock secs ( 0.05 usr  0.01 sys +  2.32 cusr  0.95 csys =  3.34 CPU)
Result: FAIL
```

なぜこのようになるのか深追いできていないのですが、同様の内容も見付かるようです。。。
- http://www.nntp.perl.org/group/perl.perl5.porters/2012/11/msg195373.html
- https://www.ruby-forum.com/topic/4315656
- http://stackoverflow.com/questions/4029291/why-would-connect-give-intermittent-einval-on-port-to-freebsd

よろしければ、マージをお願いします！
