### PR TITLE
fix "Use of uninitialized value $nwrite"

### DIFF
--- a/lib/Fluent/Logger.pm
+++ b/lib/Fluent/Logger.pm
@@ -281,13 +281,14 @@ sub _write {
         my $nwrite
             = $self->socket_io->syswrite($data, $self->write_length, $written);
 
-        unless ($nwrite) {
+        if (!$nwrite) {
             if ($retry > $self->max_write_retry) {
                 die "failed write retry; max write retry count. $!";
             }
             $retry++;
+        } else {
+            $written += $nwrite;
         }
-        $written += $nwrite;
     }
     $written;
 }


### PR DESCRIPTION
During stress testing, I got the following warning:
```
Use of uninitialized value $nwrite in addition (+) at /home/skaji/env/plenv/versions/relocatable-5.20.1/lib/site_perl/5.20.1/Fluent/Logger.pm line 290.
```
This patch would fix this.