### PR TITLE
Called the buffer_overflow_handler at close()

### DIFF
--- a/lib/Fluent/Logger.pm
+++ b/lib/Fluent/Logger.pm
@@ -140,6 +140,7 @@ sub close {
         if ($@ || !$written) {
             my $size = length $self->{pending};
             $self->_carp("Can't send pending data. LOST $size bytes.: $@");
+            $self->_call_buffer_overflow_handler();
         }
         else {
             $self->_carp("pending data was flushed successfully");
@@ -341,6 +342,7 @@ You can inject your own custom coderef to handle buffer overflow in the event of
 This will mitigate the loss of data instead of simply throwing data away.
 
 Your proc should accept a single argument, which will be the internal buffer of messages from the logger.
+This coderef is also called when logger.close() failed to flush the remaining internal buffer of messages.
 A typical use-case for this would be writing to disk or possibly writing to Redis.
 
 =item truncate_buffer_at_overflow

--- a/t/09_buffer_overflow_handler.t
+++ b/t/09_buffer_overflow_handler.t
@@ -18,9 +18,10 @@ my $no_such_logger = Fluent::Logger->new(
 for (1..10) {
     $no_such_logger->post("test", { "k" => "v" x (1024 * 1024) });
 }
-undef $no_such_logger;
+is $handler_called, 1, 'called once at buffer_overflow';
 
-is $handler_called, 1;
+undef $no_such_logger;
+is $handler_called, 2, 'called once at close';
 
 done_testing;
 


### PR DESCRIPTION
ref. https://github.com/fluent/fluent-logger-ruby/blob/77a423c22dbe32f7f4cba0b5a5f94acbdfe9438d/lib/fluent/logger/fluent_logger.rb#L112

- I want to handle the remaining internal buffer of messages when logger.close() failed flushing.
- This behavior is compatible with fluent-logger-ruby.