### PR TITLE
Add ack support

### DIFF
--- a/META.json
+++ b/META.json
@@ -56,6 +56,8 @@
          "requires" : {
             "Class::Tiny" : "0",
             "Data::MessagePack" : "0.35_01",
+            "Data::MessagePack::Stream" : "0",
+            "Data::UUID" : "0",
             "Time::Piece" : "0"
          }
       }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Fluent::Logger is a structured event logger for Fluent.
         buffer_limit                => 'Int':  defualt 8388608 (8MB)
         buffer_overflow_handler     => 'Code': optional
         truncate_buffer_at_overflow => 'Bool': default 0
+        ack                         => 'Bool': default 0
 
     - buffer\_overflow\_handler
 
@@ -59,6 +60,12 @@ Fluent::Logger is a structured event logger for Fluent.
         When truncate\_buffer\_at\_overflow is true and pending buffer size is larger than buffer\_limit, post() returns undef.
 
         Pending buffer still be kept, but last message passed to post() is not sent and not appended to buffer. You may handle the message by other method.
+
+    - ack
+
+        post() waits ack response from server for each messages.
+
+        An exception will raise if ack is miss match or timed out.
 
 - **post**($tag:Str, $msg:HashRef)
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,8 @@
 requires 'Data::MessagePack', '0.35_01';
 requires 'Class::Tiny';
 requires 'Time::Piece';
+requires 'Data::MessagePack::Stream';
+requires 'Data::UUID';
 
 on build => sub {
     requires 'Capture::Tiny';

--- a/lib/Fluent/Logger.pm
+++ b/lib/Fluent/Logger.pm
@@ -245,7 +245,9 @@ sub _send {
     my $written;
     eval {
         $written = $self->_write( $self->{pending} );
-        my $acked = $self->_wait_ack(@{ $self->{pending_acks} });
+        my $acked = $self->ack
+            ? $self->_wait_ack(@{ $self->{pending_acks} })
+            : 1;
         if ($written && $acked) {
             $self->{pending} = "";
             $self->{pending_acks} = [];
@@ -276,7 +278,6 @@ sub _send {
 sub _wait_ack {
     my $self = shift;
     my @acks = @_;
-    return 1 unless $self->ack;
 
     my $up = $self->unpacker;
     local $SIG{"PIPE"} = sub { die $! };

--- a/lib/Fluent/Logger.pm
+++ b/lib/Fluent/Logger.pm
@@ -404,6 +404,7 @@ create new logger instance.
     buffer_limit                => 'Int':  defualt 8388608 (8MB)
     buffer_overflow_handler     => 'Code': optional
     truncate_buffer_at_overflow => 'Bool': default 0
+    ack                         => 'Bool': default 0
 
 =over 4
 
@@ -421,6 +422,12 @@ A typical use-case for this would be writing to disk or possibly writing to Redi
 When truncate_buffer_at_overflow is true and pending buffer size is larger than buffer_limit, post() returns undef.
 
 Pending buffer still be kept, but last message passed to post() is not sent and not appended to buffer. You may handle the message by other method.
+
+=item ack
+
+post() waits ack response from server for each messages.
+
+An exception will raise if ack is miss match or timed out.
 
 =back
 

--- a/t/04_live.t
+++ b/t/04_live.t
@@ -57,6 +57,24 @@ subtest tcp_event_time => sub {
     like $log => qr/"event_time":"bar","tag":"$tag","time":"\Q$time_str\E"/, "match post_with_time log";
 };
 
+subtest ack => sub {
+    my $logger = Fluent::Logger->new( port => $port, ack => 1 );
+
+    isa_ok $logger, "Fluent::Logger";
+    my $tag = "test.tcp";
+    ok $logger->post( $tag, { "foo" => "bar" }), "post ok";
+
+    my $time     = time - int rand(3600);
+    my $time_str = localtime($time)->strftime("%Y-%m-%dT%H:%M:%S.000000000%z");
+
+    ok $logger->post_with_time( $tag, { "FOO" => "BAR" }, $time ), "post_with_time ok";
+    sleep 1;
+    my $log = slurp_log $dir;
+    note $log;
+    like $log => qr/"foo":"bar","tag":"$tag"/, "match post log";
+    like $log => qr/"FOO":"BAR","tag":"$tag","time":"\Q$time_str\E"/, "match post_with_time log";
+};
+
 subtest error => sub {
     my $logger = Fluent::Logger->new( port => $port );
     ok $logger->post( "test.error" => { foo => "ok" } );

--- a/xt/08_benchmark_ack.t
+++ b/xt/08_benchmark_ack.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::TCP;
+use Time::HiRes qw/ time /;
+use t::Util qw/ run_fluentd /;
+
+Test::More::plan skip_all => "skip < 5.10" if $] < 5.010;
+
+my ($server, $dir) = run_fluentd();
+my $port = $server->port;
+
+require Number::Format;
+
+use_ok "Fluent::Logger";
+diag "starting benchmark...";
+for my $size ( 10, 100, 1000 ) {
+    my $n = 50000;
+    my $msg = "x" x $size;
+    my $start  = time;
+    my $logger = Fluent::Logger->new( port => $port, ack => 1 );
+    my $w = 0;
+    for ( 1 .. $n ) {
+        $w += $logger->post( "test.benchmark", { "msg" => $msg } );
+    }
+    my $elapsed = time - $start;
+    diag sprintf "%.2f sec / %d msgs (%d bytes) = %.2fqps (%sbps)",
+             $elapsed, $n, $w / $n, $n / $elapsed,
+             Number::Format::format_bytes($w * 8 / $elapsed);
+}
+
+done_testing;


### PR DESCRIPTION
Added a option `ack`.
https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v0#option

If ack is true, 
- post() waits ack response from server after send messages.
- An execption will raise if ack is mismatch or timed out.
  - Messages are stored in logger's buffer. These messages will re-send at next post().
