### PR TITLE
stop tests if module has compilation errors

### DIFF
--- a/t/00_compile.t
+++ b/t/00_compile.t
@@ -2,6 +2,6 @@ use strict;
 use Test::More;
 use ExtUtils::MakeMaker ();
 
-BEGIN { use_ok 'Fluent::Logger' }
+BEGIN { use_ok 'Fluent::Logger' or BAIL_OUT('will not work with compilation problems'); }
 
 done_testing;


### PR DESCRIPTION
prevents hanging on Windows due to missing Data::MessagePack::Stream