### PR TITLE
Add retry_immediately option.

### DIFF
--- a/lib/Fluent/Logger.pm
+++ b/lib/Fluent/Logger.pm
@@ -436,7 +436,7 @@ This option does not work on MSWin32 platform currently, because Data::MessagePa
 
 =item retry_immediately
 
-When an error occured in post(), Fluent::Logger will retry to send the buffer at next post() called.
+By default, Fluent::Logger will retry to send the buffer at next post() called when an error occured in post().
 
 If retry_immediately(N) is set, retries immediately max N times.
 

--- a/t/11_retry_immediately.t
+++ b/t/11_retry_immediately.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../";
+use Test::More;
+use t::Util qw/ run_fluentd /;
+use POSIX qw/ setlocale LC_ALL /;
+use Test::SharedFork;
+
+use Config;
+if ( $Config{d_setlocale} ) {
+    setlocale(LC_ALL, "C");
+}
+
+my ($server, $dir) = run_fluentd();
+my $port = $server->port;
+
+use_ok "Fluent::Logger";
+
+my $logger = Fluent::Logger->new(
+   port              => $port,
+   retry_immediately => 1,
+);
+
+ok $logger->post( "test.error" => { foo => "ok" } );
+
+undef $server; # shutdown
+sleep 1;
+
+($server, $dir) = run_fluentd($port); # start fluentd on the same port
+
+ok $logger->post( "test.error" => { foo => "retried?" } );
+
+done_testing;


### PR DESCRIPTION
By default, Fluent::Logger will retry to send the buffer at next post() called when an error occured in post().

If retry_immediately(N) is set, retries immediately max N times.
