### PR TITLE
Switch from Path::Class to Path::Tiny

### DIFF
--- a/META.json
+++ b/META.json
@@ -30,7 +30,7 @@
          "requires" : {
             "Capture::Tiny" : "0",
             "ExtUtils::MakeMaker" : "6.36",
-            "Path::Class" : "0",
+            "Path::Tiny" : "0.028",
             "Test::More" : "0.88",
             "Test::SharedFork" : "0",
             "Test::TCP" : "1.3",

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -2,7 +2,7 @@ package t::Util;
 use strict;
 use warnings;
 use File::Temp qw/ tempdir /;
-use Path::Class qw/ dir /;
+use Path::Tiny qw/ path /;
 use Test::TCP;
 use version;
 
@@ -24,7 +24,7 @@ sub streaming_decode_mp {
 
 sub slurp_log($) {
     my $dir = shift;
-    my @file = grep { !/\.meta$/ } grep { /test\.log/ } dir($dir)->children;
+    my @file = grep { !/\.meta$/ } path($dir)->children( qr/test\.log/ );
     return join("", map { $_->slurp } @file);
 }
 


### PR DESCRIPTION
The tests for this module use Path::Class, but Path::Tiny accomplishes the same with no non-core dependencies and is currently much better maintained (Path::Class hasn't seen a release since 2016).

The requirement of 0.028 is because that was the version where [the optional regex for `children` was added](https://metacpan.org/source/DAGOLDEN/Path-Tiny-0.112/Changes#L655).