### PR TITLE
set Data::MessagePack->utf8(1) by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Fluent::Logger is a structured event logger for Fluentd.
         timeout                     => 'Num':  default is 3.0
         socket                      => 'Str':  default undef (e.g. "/var/run/fluent/fluent.sock")
         prefer_integer              => 'Bool': default 1 (set to Data::MessagePack->prefer_integer)
+        utf8                        => 'Bool': default 1 (set to Data::MessagePack->utf8)
         event_time                  => 'Bool': default 0 (timestamp includes nanoseconds, supported by fluentd >= 0.14.0)
         buffer_limit                => 'Int':  defualt 8388608 (8MB)
         buffer_overflow_handler     => 'Code': optional

--- a/lib/Fluent/Logger.pm
+++ b/lib/Fluent/Logger.pm
@@ -42,9 +42,11 @@ use Class::Tiny +{
     socket_io => sub {},
     errors => sub { [] },
     prefer_integer => sub { 1 },
+    utf8 => sub { 1 },
     packer => sub {
         my $self = shift;
         my $mp   = Data::MessagePack->new;
+        $mp->utf8( $self->utf8 );
         $mp->prefer_integer( $self->prefer_integer );
         $mp;
     },
@@ -402,6 +404,7 @@ create new logger instance.
     timeout                     => 'Num':  default is 3.0
     socket                      => 'Str':  default undef (e.g. "/var/run/fluent/fluent.sock")
     prefer_integer              => 'Bool': default 1 (set to Data::MessagePack->prefer_integer)
+    utf8                        => 'Bool': default 1 (set to Data::MessagePack->utf8)
     event_time                  => 'Bool': default 0 (timestamp includes nanoseconds, supported by fluentd >= 0.14.0)
     buffer_limit                => 'Int':  defualt 8388608 (8MB)
     buffer_overflow_handler     => 'Code': optional

--- a/t/07_str_utf8.t
+++ b/t/07_str_utf8.t
@@ -21,10 +21,10 @@ my $port = $server->port;
 use_ok "Fluent::Logger";
 
 subtest str_bin => sub {
-    my $logger = Fluent::Logger->new( port => $port, utf8 => 0 );
+    my $logger = Fluent::Logger->new( port => $port, utf8 => 1 );
 
     isa_ok $logger, "Fluent::Logger";
-    is $logger->packer->get_utf8, 0, "packer utf8 is off";
+    is $logger->packer->get_utf8, 1, "packer utf8 is on";
     my $tag = "test.tcp";
     ok $logger->post( $tag, { "foo" => decode_utf8("内部文字列") }), "post str ok";
     ok $logger->post( $tag, { "bar" => "バイナリ列" }), "post bin ok";


### PR DESCRIPTION
fixes #32

Send any strings packed as msgpack str type.
For backward compatibility, Fluent::Logger->utf8 is also added.